### PR TITLE
Wrap all exported self modifying functions

### DIFF
--- a/src/_construct.js
+++ b/src/_construct.js
@@ -11,11 +11,11 @@ function isNativeReflectConstruct() {
   }
 }
 
-export default function _construct(Parent, args, Class) {
+function construct(Parent, args, Class) {
   if (isNativeReflectConstruct()) {
-    _construct = Reflect.construct;
+    construct = Reflect.construct;
   } else {
-    _construct = function _construct(Parent, args, Class) {
+    construct = function construct(Parent, args, Class) {
       var a = [null];
       a.push.apply(a, args);
       var Constructor = Function.bind.apply(Parent, a);
@@ -25,5 +25,9 @@ export default function _construct(Parent, args, Class) {
     };
   }
 
-  return _construct.apply(null, arguments);
+  return construct.apply(null, arguments);
+}
+
+export default function _construct(Parent, args, Class) {
+  return construct.apply(null, arguments);
 }

--- a/src/_extends.js
+++ b/src/_extends.js
@@ -1,5 +1,5 @@
-export default function _extends() {
-  _extends = Object.assign || function (target) {
+function extends_() {
+  extends_ = Object.assign || function (target) {
     for (var i = 1; i < arguments.length; i++) {
       var source = arguments[i];
 
@@ -13,5 +13,9 @@ export default function _extends() {
     return target;
   };
 
-  return _extends.apply(this, arguments);
+  return extends_.apply(this, arguments);
+}
+
+export default function _extends() {
+  return extends_.apply(this, arguments);
 }

--- a/src/_get.js
+++ b/src/_get.js
@@ -1,21 +1,25 @@
-import superPropBase from './_super_prop_base';
+import superPropBase from "./_super_prop_base";
 
-export default function _get(target, property, receiver) {
+export default function get(target, property, receiver) {
   if (typeof Reflect !== "undefined" && Reflect.get) {
-    _get = Reflect.get;
+    get = Reflect.get;
   } else {
-    _get = function _get(target, property, receiver) {
+    get = function get(target, property, receiver) {
       var base = superPropBase(target, property);
       if (!base) return;
       var desc = Object.getOwnPropertyDescriptor(base, property);
 
       if (desc.get) {
-        return desc.get.call(receiver);
+        return desc.get.call(receiver || target);
       }
 
       return desc.value;
     };
   }
 
-  return _get(target, property, receiver || target);
+  return get(target, property, receiver);
+}
+
+export default function _get(target, property, reciever) {
+  return get(target, property, reciever);
 }

--- a/src/_get.js
+++ b/src/_get.js
@@ -1,4 +1,4 @@
-import superPropBase from "./_super_prop_base";
+import superPropBase from './_super_prop_base';
 
 export default function get(target, property, receiver) {
   if (typeof Reflect !== "undefined" && Reflect.get) {

--- a/src/_get.js
+++ b/src/_get.js
@@ -1,6 +1,6 @@
 import superPropBase from './_super_prop_base';
 
-export default function get(target, property, receiver) {
+function get(target, property, receiver) {
   if (typeof Reflect !== "undefined" && Reflect.get) {
     get = Reflect.get;
   } else {

--- a/src/_get_prototype_of.js
+++ b/src/_get_prototype_of.js
@@ -1,6 +1,10 @@
-export default function _getPrototypeOf(o) {
-  _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {
+export default function getPrototypeOf(o) {
+  getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function getPrototypeOf(o) {
     return o.__proto__ || Object.getPrototypeOf(o);
   };
-  return _getPrototypeOf(o);
+  return getPrototypeOf(o);
+}
+
+export default function _getPrototypeOf(o) {
+  return getPrototypeOf(o);
 }

--- a/src/_get_prototype_of.js
+++ b/src/_get_prototype_of.js
@@ -1,4 +1,4 @@
-export default function getPrototypeOf(o) {
+function getPrototypeOf(o) {
   getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function getPrototypeOf(o) {
     return o.__proto__ || Object.getPrototypeOf(o);
   };

--- a/src/_set_prototype_of.js
+++ b/src/_set_prototype_of.js
@@ -1,8 +1,12 @@
-export default function _setPrototypeOf(o, p) {
-  _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
+function setPrototypeOf(o, p) {
+  setPrototypeOf = Object.setPrototypeOf || function setPrototypeOf(o, p) {
     o.__proto__ = p;
     return o;
   };
 
-  return _setPrototypeOf(o, p);
+  return setPrototypeOf(o, p);
+}
+
+export default function _setPrototypeOf(o, p) {
+  return setPrototypeOf(o, p);
 }

--- a/src/_wrap_native_super.js
+++ b/src/_wrap_native_super.js
@@ -3,10 +3,10 @@ import isNativeFunction from './_is_native_function';
 import getPrototypeOf from './_get_prototype_of';
 import setPrototypeOf from './_set_prototype_of';
 
-export default function _wrapNativeSuper(Class) {
+function wrapNativeSuper(Class) {
   var _cache = typeof Map === "function" ? new Map() : undefined;
 
-  _wrapNativeSuper = function _wrapNativeSuper(Class) {
+  wrapNativeSuper = function wrapNativeSuper(Class) {
     if (Class === null || !isNativeFunction(Class)) return Class;
 
     if (typeof Class !== "function") {
@@ -34,5 +34,9 @@ export default function _wrapNativeSuper(Class) {
     return setPrototypeOf(Wrapper, Class);
   };
 
-  return _wrapNativeSuper(Class);
+  return wrapNativeSuper(Class);
+}
+
+export default function _wrapNativeSuper(Class) {
+  return wrapNativeSuper(Class);
 }


### PR DESCRIPTION
Hello,

When investigating swc-project/swc#1555, I have found that in some cases, the injected helper function was not updated and recreated itself on each call.

This is not a use case that would occur naturally by using `swc` only.
My use case involve tree shaking and code splitting from rollup, where it changes the generated code in a similar way as below:

```diff
- import * as swcHelpers from `@swc/helpers`;
- swcHelpers.wrapNativeSuper(/*...*/);
+ import { wrapNativeSuper } from `chunk_abcdef.js`;
+ wrapNativeSuper(/*...*/);
```

The changes I propose in this PR is to keep the lazy implementation choice (which can be good if polyfill are included later) but wrap it all in a function that will not change.