### PR TITLE
workaround swc-project/swc#1462 in objectSpread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# @swc/helpers
+Hepers used by swc
+
+## Setup & Building
+```bash
+npm install
+./scripts/gen.sh
+```

--- a/scripts/gen.sh
+++ b/scripts/gen.sh
@@ -2,4 +2,4 @@
 set -eu
 
 ./scripts/generator.sh > src/index.js
-npm build
+npm run-script build

--- a/src/_object_spread.js
+++ b/src/_object_spread.js
@@ -1,14 +1,17 @@
 import defineProperty from './_define_property';
 
 export default function _objectSpread(target) {
-  for (var i = 1; i < arguments.length; i++) {
-    var source = arguments[i] != null ? arguments[i] : {};
+  const vargs = arguments;
+  for (var i = 1; i < vargs.length; i++) {
+    var source = vargs[i] != null ? vargs[i] : {};
     var ownKeys = Object.keys(source);
 
-    if (typeof Object.getOwnPropertySymbols === 'function') {
-      ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) {
-        return Object.getOwnPropertyDescriptor(source, sym).enumerable;
-      }));
+    if (typeof Object.getOwnPropertySymbols === "function") {
+      ownKeys = ownKeys.concat(
+        Object.getOwnPropertySymbols(source).filter(function (sym) {
+          return Object.getOwnPropertyDescriptor(source, sym).enumerable;
+        })
+      );
     }
 
     ownKeys.forEach(function (key) {


### PR DESCRIPTION
At present, swc-project/swc#1462 means that
any project which builds using swc and uses the object-spread helper
will not object-spread correctly.

This workaround manually binds `arguments` to a new name to sidestep
that issue.

I also took the liberty of updating gen.sh to run the build task via
`npm run-script`, which should reliably run the build task on npm@6
as well as on npm@7, and added a README with some terse instructions
for new contributors on how to get started and build.
https://docs.npmjs.com/cli/v7/commands/npm-run-script

Fixes #5