### PR TITLE
Add module and sideEffects entries to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.2.10",
   "description": "",
   "esnext": "src/index.js",
+  "module": "src/index.js",
   "main": "lib/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "swc -V && swc src -d lib",
     "prepublishOnly": "swc src -d lib",


### PR DESCRIPTION
This adds `"module": "src/index.js"` and `"sideEffects": false` entries to the package.json, allowing bundlers like Parcel to better scope-hoist and tree-shake swc helpers. Because swc inserts imports as `* as swcHelpers` from this package, without proper tree-shaking unnecessary helpers can be included in bundler output.

**From a quick look through the source, the helpers seem to be side-effect-free. Please confirm this is the case.**

**Please also confirm that the helpers will continue to be written in esm+es5-style JavaScript.  Many bundlers won't automatically downlevel external packages so es5 continues to be a good common denominator.**

Lastly, I'm still working on getting the swc CLA signed. Please don't merge this until I have.

Thanks 😄 

Test Plan: 
* Built a swc-transformed file with object spread using Parcel, running the result through terser.
* Verifed that the output only contained the object spread helper and defineProperty helper. Previously, other unused helpers were included.